### PR TITLE
Add landing page schema

### DIFF
--- a/apps/backend/prisma/migrations/20250807194001_add_landing/migration.sql
+++ b/apps/backend/prisma/migrations/20250807194001_add_landing/migration.sql
@@ -1,0 +1,365 @@
+/*
+  Warnings:
+
+  - The primary key for the `files` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[headerId]` on the table `files` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[newsId]` on the table `files` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[blogId]` on the table `files` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[contactId]` on the table `files` will be added. If there are existing duplicate values, this will fail.
+  - Changed the type of `id` on the `files` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "files" DROP CONSTRAINT "files_pkey",
+ADD COLUMN     "blogId" UUID,
+ADD COLUMN     "contactId" UUID,
+ADD COLUMN     "headerId" UUID,
+ADD COLUMN     "newsId" UUID,
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL,
+ADD CONSTRAINT "files_pkey" PRIMARY KEY ("id");
+
+-- CreateTable
+CREATE TABLE "header" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "fileId" TEXT,
+
+    CONSTRAINT "header_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "introduce" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "fileId" TEXT,
+
+    CONSTRAINT "introduce_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "news" (
+    "id" UUID NOT NULL,
+    "slug" TEXT NOT NULL,
+    "showInLanding" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER,
+    "metaTitle" TEXT,
+    "metaDescription" TEXT,
+    "metaKeywords" TEXT,
+    "metaImage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "news_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "services" (
+    "id" UUID NOT NULL,
+    "iconId" UUID,
+    "backgroundId" UUID,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "services_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "faqs" (
+    "id" UUID NOT NULL,
+    "order" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "faqs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "blogs" (
+    "id" UUID NOT NULL,
+    "stars" INTEGER NOT NULL DEFAULT 0,
+    "slug" TEXT NOT NULL,
+    "showInLanding" BOOLEAN NOT NULL DEFAULT false,
+    "landingOrder" INTEGER NOT NULL DEFAULT 0,
+    "metaTitle" TEXT,
+    "metaDescription" TEXT,
+    "metaKeywords" TEXT,
+    "metaImage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "blogs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contacts" (
+    "id" UUID NOT NULL,
+    "location" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contacts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "header_translations" (
+    "id" UUID NOT NULL,
+    "headline" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "headerId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "header_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "introduce_translations" (
+    "id" UUID NOT NULL,
+    "headline" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "introduceId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "introduce_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "news_translations" (
+    "id" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "newsId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "news_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "service_translations" (
+    "id" UUID NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "serviceId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "service_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "faq_translations" (
+    "id" UUID NOT NULL,
+    "question" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "faqId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "faq_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "blog_translations" (
+    "id" UUID NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "blogId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "blog_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "category_translations" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "categoryId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "category_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contact_translations" (
+    "id" UUID NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "contactId" UUID NOT NULL,
+    "languageId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contact_translations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_BlogToCategory" (
+    "A" UUID NOT NULL,
+    "B" UUID NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_BlogStars" (
+    "A" UUID NOT NULL,
+    "B" UUID NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "news_slug_key" ON "news"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "services_iconId_key" ON "services"("iconId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "services_backgroundId_key" ON "services"("backgroundId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "blogs_slug_key" ON "blogs"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "header_translations_headerId_languageId_key" ON "header_translations"("headerId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "introduce_translations_introduceId_languageId_key" ON "introduce_translations"("introduceId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "news_translations_newsId_languageId_key" ON "news_translations"("newsId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "service_translations_serviceId_languageId_key" ON "service_translations"("serviceId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "faq_translations_faqId_languageId_key" ON "faq_translations"("faqId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "blog_translations_blogId_languageId_key" ON "blog_translations"("blogId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "category_translations_categoryId_languageId_key" ON "category_translations"("categoryId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "contact_translations_contactId_languageId_key" ON "contact_translations"("contactId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_BlogToCategory_AB_unique" ON "_BlogToCategory"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_BlogToCategory_B_index" ON "_BlogToCategory"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_BlogStars_AB_unique" ON "_BlogStars"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_BlogStars_B_index" ON "_BlogStars"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "files_headerId_key" ON "files"("headerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "files_newsId_key" ON "files"("newsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "files_blogId_key" ON "files"("blogId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "files_contactId_key" ON "files"("contactId");
+
+-- AddForeignKey
+ALTER TABLE "files" ADD CONSTRAINT "files_headerId_fkey" FOREIGN KEY ("headerId") REFERENCES "header"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "files" ADD CONSTRAINT "files_newsId_fkey" FOREIGN KEY ("newsId") REFERENCES "news"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "files" ADD CONSTRAINT "files_blogId_fkey" FOREIGN KEY ("blogId") REFERENCES "blogs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "files" ADD CONSTRAINT "files_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "contacts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "services" ADD CONSTRAINT "services_iconId_fkey" FOREIGN KEY ("iconId") REFERENCES "files"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "services" ADD CONSTRAINT "services_backgroundId_fkey" FOREIGN KEY ("backgroundId") REFERENCES "files"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "header_translations" ADD CONSTRAINT "header_translations_headerId_fkey" FOREIGN KEY ("headerId") REFERENCES "header"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "header_translations" ADD CONSTRAINT "header_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "introduce_translations" ADD CONSTRAINT "introduce_translations_introduceId_fkey" FOREIGN KEY ("introduceId") REFERENCES "introduce"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "introduce_translations" ADD CONSTRAINT "introduce_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "news_translations" ADD CONSTRAINT "news_translations_newsId_fkey" FOREIGN KEY ("newsId") REFERENCES "news"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "news_translations" ADD CONSTRAINT "news_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "service_translations" ADD CONSTRAINT "service_translations_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "services"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "service_translations" ADD CONSTRAINT "service_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "faq_translations" ADD CONSTRAINT "faq_translations_faqId_fkey" FOREIGN KEY ("faqId") REFERENCES "faqs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "faq_translations" ADD CONSTRAINT "faq_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blog_translations" ADD CONSTRAINT "blog_translations_blogId_fkey" FOREIGN KEY ("blogId") REFERENCES "blogs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blog_translations" ADD CONSTRAINT "blog_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "category_translations" ADD CONSTRAINT "category_translations_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "category_translations" ADD CONSTRAINT "category_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contact_translations" ADD CONSTRAINT "contact_translations_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "contacts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contact_translations" ADD CONSTRAINT "contact_translations_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "languages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogToCategory" ADD CONSTRAINT "_BlogToCategory_A_fkey" FOREIGN KEY ("A") REFERENCES "blogs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogToCategory" ADD CONSTRAINT "_BlogToCategory_B_fkey" FOREIGN KEY ("B") REFERENCES "categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogStars" ADD CONSTRAINT "_BlogStars_A_fkey" FOREIGN KEY ("A") REFERENCES "blogs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogStars" ADD CONSTRAINT "_BlogStars_B_fkey" FOREIGN KEY ("B") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -9,10 +9,12 @@ model Language {
   introduceTranslations IntroduceTranslation[]
   newsTranslations      NewsTranslation[]
   serviceTranslations   ServiceTranslation[]
+  FAQTranslations       FAQTranslation[]
+  blogTranslations      BlogTranslation[]
+  categoryTranslations  CategoryTranslation[]
 
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
-  FAQTranslation FAQTranslation[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@map("languages")
 }
@@ -24,10 +26,13 @@ model File {
   path String
   size Int
 
-  header            Header?  @relation(fields: [headerId], references: [id], onDelete: Cascade)
-  headerId          String?  @unique @db.Uuid
-  news              News?    @relation(fields: [newsId], references: [id], onDelete: Cascade)
-  newsId            String?  @unique @db.Uuid
+  header   Header? @relation(fields: [headerId], references: [id], onDelete: Cascade)
+  headerId String? @unique @db.Uuid
+  news     News?   @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  newsId   String? @unique @db.Uuid
+  blog     Blog?   @relation(fields: [blogId], references: [id], onDelete: Cascade)
+  blogId   String? @unique @db.Uuid
+
   serviceIcon       Service? @relation("ServiceIcon")
   serviceBackground Service? @relation("ServiceBackground")
 
@@ -126,4 +131,40 @@ model FAQ {
   updatedAt DateTime @updatedAt
 
   @@map("faqs")
+}
+
+model Blog {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  background   File?
+  categories   Category[]
+  starredUsers User[]            @relation("BlogStars")
+  stars        Int               @default(0)
+  translations BlogTranslation[]
+
+  slug          String  @unique
+  showInLanding Boolean @default(false)
+  landingOrder  Int     @default(0)
+
+  metaTitle       String?
+  metaDescription String?
+  metaKeywords    String?
+  metaImage       String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("blogs")
+}
+
+model Category {
+  id String @id @default(uuid())
+
+  blogs        Blog[]
+  translations CategoryTranslation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("categories")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -10,8 +10,9 @@ model Language {
   newsTranslations      NewsTranslation[]
   serviceTranslations   ServiceTranslation[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+  FAQTranslation FAQTranslation[]
 
   @@map("languages")
 }
@@ -113,4 +114,16 @@ model Service {
   updatedAt DateTime @updatedAt
 
   @@map("services")
+}
+
+model FAQ {
+  id String @id @default(uuid())
+
+  order        Int              @default(autoincrement())
+  translations FAQTranslation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("faqs")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -7,6 +7,7 @@ model Language {
 
   headerTranslations    HeaderTranslation[]
   introduceTranslations IntroduceTranslation[]
+  newsTranslations      NewsTranslation[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -23,6 +24,8 @@ model File {
 
   header   Header? @relation(fields: [headerId], references: [id], onDelete: Cascade)
   headerId String? @unique @db.Uuid
+  news     News?   @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  newsId   String? @unique @db.Uuid
 
   deletedAt DateTime?
   createdAt DateTime  @default(now())
@@ -70,4 +73,24 @@ model Introduce {
   fileId    String?
 
   @@map("introduce")
+}
+
+model News {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  slug          String            @unique
+  background    File?
+  translations  NewsTranslation[]
+  showInLanding Boolean           @default(false)
+  order         Int?
+
+  metaTitle       String?
+  metaDescription String?
+  metaKeywords    String?
+  metaImage       String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("news")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -12,6 +12,7 @@ model Language {
   FAQTranslations       FAQTranslation[]
   blogTranslations      BlogTranslation[]
   categoryTranslations  CategoryTranslation[]
+  contactTranslations   ContactTranslation[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -20,18 +21,20 @@ model Language {
 }
 
 model File {
-  id String @id @default(uuid())
+  id String @id @default(uuid()) @db.Uuid
 
   name String
   path String
   size Int
 
-  header   Header? @relation(fields: [headerId], references: [id], onDelete: Cascade)
-  headerId String? @unique @db.Uuid
-  news     News?   @relation(fields: [newsId], references: [id], onDelete: Cascade)
-  newsId   String? @unique @db.Uuid
-  blog     Blog?   @relation(fields: [blogId], references: [id], onDelete: Cascade)
-  blogId   String? @unique @db.Uuid
+  header    Header?  @relation(fields: [headerId], references: [id], onDelete: Cascade)
+  headerId  String?  @unique @db.Uuid
+  news      News?    @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  newsId    String?  @unique @db.Uuid
+  blog      Blog?    @relation(fields: [blogId], references: [id], onDelete: Cascade)
+  blogId    String?  @unique @db.Uuid
+  contact   Contact? @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  contactId String?  @unique @db.Uuid
 
   serviceIcon       Service? @relation("ServiceIcon")
   serviceBackground Service? @relation("ServiceBackground")
@@ -105,7 +108,7 @@ model News {
 }
 
 model Service {
-  id String @id @default(uuid())
+  id String @id @default(uuid()) @db.Uuid
 
   translations ServiceTranslation[]
 
@@ -122,7 +125,7 @@ model Service {
 }
 
 model FAQ {
-  id String @id @default(uuid())
+  id String @id @default(uuid(7)) @db.Uuid
 
   order        Int              @default(autoincrement())
   translations FAQTranslation[]
@@ -158,7 +161,7 @@ model Blog {
 }
 
 model Category {
-  id String @id @default(uuid())
+  id String @id @default(uuid()) @db.Uuid
 
   blogs        Blog[]
   translations CategoryTranslation[]
@@ -167,4 +170,17 @@ model Category {
   updatedAt DateTime @updatedAt
 
   @@map("categories")
+}
+
+model Contact {
+  id String @id @default(uuid()) @db.Uuid
+
+  location     String?
+  background   File?
+  translations ContactTranslation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("contacts")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -8,6 +8,7 @@ model Language {
   headerTranslations    HeaderTranslation[]
   introduceTranslations IntroduceTranslation[]
   newsTranslations      NewsTranslation[]
+  serviceTranslations   ServiceTranslation[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -22,10 +23,12 @@ model File {
   path String
   size Int
 
-  header   Header? @relation(fields: [headerId], references: [id], onDelete: Cascade)
-  headerId String? @unique @db.Uuid
-  news     News?   @relation(fields: [newsId], references: [id], onDelete: Cascade)
-  newsId   String? @unique @db.Uuid
+  header            Header?  @relation(fields: [headerId], references: [id], onDelete: Cascade)
+  headerId          String?  @unique @db.Uuid
+  news              News?    @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  newsId            String?  @unique @db.Uuid
+  serviceIcon       Service? @relation("ServiceIcon")
+  serviceBackground Service? @relation("ServiceBackground")
 
   deletedAt DateTime?
   createdAt DateTime  @default(now())
@@ -93,4 +96,21 @@ model News {
   updatedAt DateTime @updatedAt
 
   @@map("news")
+}
+
+model Service {
+  id String @id @default(uuid())
+
+  translations ServiceTranslation[]
+
+  icon   File?   @relation("ServiceIcon", fields: [iconId], references: [id], onDelete: Cascade)
+  iconId String? @unique @db.Uuid
+
+  background   File?   @relation("ServiceBackground", fields: [backgroundId], references: [id], onDelete: Cascade)
+  backgroundId String? @unique @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("services")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -5,6 +5,8 @@ model Language {
   name  String
   order Int    @default(autoincrement())
 
+  headerTranslations HeaderTranslation[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -17,6 +19,9 @@ model File {
   name String
   path String
   size Int
+
+  header   Header? @relation(fields: [headerId], references: [id], onDelete: Cascade)
+  headerId String? @unique @db.Uuid
 
   deletedAt DateTime?
   createdAt DateTime  @default(now())
@@ -38,4 +43,18 @@ model RefreshToken {
   updatedAt DateTime @updatedAt
 
   @@map("refresh_tokens")
+}
+
+model Header {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  logo File?
+
+  translations HeaderTranslation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  fileId    String?
+
+  @@map("header")
 }

--- a/apps/backend/prisma/schema/global.prisma
+++ b/apps/backend/prisma/schema/global.prisma
@@ -5,7 +5,8 @@ model Language {
   name  String
   order Int    @default(autoincrement())
 
-  headerTranslations HeaderTranslation[]
+  headerTranslations    HeaderTranslation[]
+  introduceTranslations IntroduceTranslation[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -57,4 +58,16 @@ model Header {
   fileId    String?
 
   @@map("header")
+}
+
+model Introduce {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  translations IntroduceTranslation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  fileId    String?
+
+  @@map("introduce")
 }

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -5,14 +5,15 @@ model HeaderTranslation {
   description String
 
   header   Header @relation(fields: [headerId], references: [id], onDelete: Cascade)
-  headerId String @unique @db.Uuid
+  headerId String @db.Uuid
 
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String   @unique @db.Uuid
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([headerId, languageId])
   @@map("header_translations")
 }
 
@@ -23,14 +24,15 @@ model IntroduceTranslation {
   description String
 
   introduce   Introduce @relation(fields: [introduceId], references: [id], onDelete: Cascade)
-  introduceId String    @unique @db.Uuid
+  introduceId String    @db.Uuid
 
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String   @unique @db.Uuid
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([introduceId, languageId])
   @@map("introduce_translations")
 }
 
@@ -40,27 +42,28 @@ model NewsTranslation {
   content String
 
   news   News   @relation(fields: [newsId], references: [id], onDelete: Cascade)
-  newsId String @unique @db.Uuid
+  newsId String @db.Uuid
 
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String   @unique @db.Uuid
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([newsId, languageId])
   @@map("news_translations")
 }
 
 model ServiceTranslation {
-  id String @id @default(uuid())
+  id String @id @default(uuid(7)) @db.Uuid
 
   title       String
   description String
 
   service    Service  @relation(fields: [serviceId], references: [id], onDelete: Cascade)
-  serviceId  String
+  serviceId  String   @db.Uuid
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -70,15 +73,15 @@ model ServiceTranslation {
 }
 
 model FAQTranslation {
-  id String @id @default(uuid())
+  id String @id @default(uuid(7)) @db.Uuid
 
   question String
   answer   String
 
   faq        FAQ      @relation(fields: [faqId], references: [id], onDelete: Cascade)
-  faqId      String
+  faqId      String   @db.Uuid
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -88,15 +91,15 @@ model FAQTranslation {
 }
 
 model BlogTranslation {
-  id String @id @default(uuid())
+  id String @id @default(uuid(7)) @db.Uuid
 
   title   String
   content String
 
   blog       Blog     @relation(fields: [blogId], references: [id], onDelete: Cascade)
-  blogId     String
+  blogId     String   @db.Uuid
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -106,18 +109,36 @@ model BlogTranslation {
 }
 
 model CategoryTranslation {
-  id String @id @default(uuid())
+  id String @id @default(uuid(7)) @db.Uuid
 
   name String
 
   category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
-  categoryId String
+  categoryId String   @db.Uuid
   language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
-  languageId String
+  languageId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@unique([categoryId, languageId])
   @@map("category_translations")
+}
+
+model ContactTranslation {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  title       String
+  description String
+
+  contact    Contact  @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  contactId  String   @db.Uuid
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String   @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([contactId, languageId])
+  @@map("contact_translations")
 }

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -33,3 +33,20 @@ model IntroduceTranslation {
 
   @@map("introduce_translations")
 }
+
+model NewsTranslation {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  content String
+
+  news   News   @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  newsId String @unique @db.Uuid
+
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String   @unique @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("news_translations")
+}

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -50,3 +50,21 @@ model NewsTranslation {
 
   @@map("news_translations")
 }
+
+model ServiceTranslation {
+  id String @id @default(uuid())
+
+  title       String
+  description String
+
+  service    Service  @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId  String
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([serviceId, languageId])
+  @@map("service_translations")
+}

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -86,3 +86,38 @@ model FAQTranslation {
   @@unique([faqId, languageId])
   @@map("faq_translations")
 }
+
+model BlogTranslation {
+  id String @id @default(uuid())
+
+  title   String
+  content String
+
+  blog       Blog     @relation(fields: [blogId], references: [id], onDelete: Cascade)
+  blogId     String
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([blogId, languageId])
+  @@map("blog_translations")
+}
+
+model CategoryTranslation {
+  id String @id @default(uuid())
+
+  name String
+
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  categoryId String
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([categoryId, languageId])
+  @@map("category_translations")
+}

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -1,0 +1,17 @@
+model HeaderTranslation {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  headline    String
+  description String
+
+  header   Header @relation(fields: [headerId], references: [id], onDelete: Cascade)
+  headerId String @unique @db.Uuid
+
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String   @unique @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("header_translations")
+}

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -15,3 +15,21 @@ model HeaderTranslation {
 
   @@map("header_translations")
 }
+
+model IntroduceTranslation {
+  id String @id @default(uuid(7)) @db.Uuid
+
+  headline    String
+  description String
+
+  introduce   Introduce @relation(fields: [introduceId], references: [id], onDelete: Cascade)
+  introduceId String    @unique @db.Uuid
+
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String   @unique @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("introduce_translations")
+}

--- a/apps/backend/prisma/schema/translations.prisma
+++ b/apps/backend/prisma/schema/translations.prisma
@@ -68,3 +68,21 @@ model ServiceTranslation {
   @@unique([serviceId, languageId])
   @@map("service_translations")
 }
+
+model FAQTranslation {
+  id String @id @default(uuid())
+
+  question String
+  answer   String
+
+  faq        FAQ      @relation(fields: [faqId], references: [id], onDelete: Cascade)
+  faqId      String
+  language   Language @relation(fields: [languageId], references: [id], onDelete: Cascade)
+  languageId String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([faqId, languageId])
+  @@map("faq_translations")
+}

--- a/apps/backend/prisma/schema/user.prisma
+++ b/apps/backend/prisma/schema/user.prisma
@@ -6,6 +6,8 @@ model User {
   personalId String? @unique
   fullName   String? @db.VarChar(255)
 
+  starredBlogs Blog[] @relation("BlogStars")
+
   phoneNumber  String  @unique
   passwordHash String?
 

--- a/apps/backend/prisma/seedData/users.ts
+++ b/apps/backend/prisma/seedData/users.ts
@@ -4,9 +4,9 @@ import * as bcrypt from "bcrypt";
 
 const users: Prisma.AdminCreateInput[] = [
   {
-    email: "beka.chaduneli.1@btu.edu.ge",
-    firstName: "Beka",
-    lastName: "Chaduneli",
+    email: getEnvVariable("email"),
+    firstName: getEnvVariable("adminFirstName"),
+    lastName: getEnvVariable("adminLastName"),
     passwordHash: bcrypt.hashSync(
       getEnvVariable("adminPassword"),
       +getEnvVariable("saltRounds")

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -17,6 +17,9 @@ const envVariables = {
   nodeEnv: process.env.NODE_ENV,
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   RESPONSE_URL: process.env.RESPONSE_URL,
+  email: process.env.EMAIL,
+  adminFirstName: process.env.ADMIN_FIRST_NAME,
+  adminLastName: process.env.ADMIN_LAST_NAME,
 };
 
 type EnvVariableKey = keyof typeof envVariables;


### PR DESCRIPTION
### Landing Page Schema

---

This pull request introduces the complete Prisma schema for the PraxisSync landing page, setting the foundation for our website's data structure.

### What's Included:

* **Content Models:** Adds new models for `News`, `Introduce`, `Service`, `Blog`, `FAQ`, and `Contact` sections of the website.
* **Multi-Language Support:** Integrates translation models to enable a multi-lingual landing page.
* **File Management:** Introduces a `File` model to handle image uploads for various content types.

### Summary

These changes establish the core data structure needed to build the landing page's backend. The new models provide a robust and organized way to manage all website content.